### PR TITLE
feat: add today button in titlebar

### DIFF
--- a/src/views/Budget/Budget.module.scss
+++ b/src/views/Budget/Budget.module.scss
@@ -9,7 +9,8 @@
   -webkit-app-region: no-drag;
   height: 1.5rem;
   position: relative;
-  margin: 0.4rem auto;
+  margin: 0.4rem;
+  margin-left: auto;
   width: 70vw;
   max-width: 40rem;
   overflow: hidden;
@@ -68,4 +69,34 @@ button.unloadedMonthListEntry {
   position: sticky;
   left: 0;
   font-weight: 200;
+}
+.todayButton {
+  -webkit-app-region: no-drag;
+  display: inline-block;
+  position: relative;
+  height: 1.5rem;
+  margin: 0.4rem;
+  padding: 0rem 0.5rem;
+  margin-right: auto;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+  border-radius: 3px;
+  color: var(--main-color);
+  font-size: 0.9rem;
+  line-height: 1.5rem;
+  transition: border-color 1s;
+}
+button.todayButton {
+  cursor: pointer;
+  &:focus {
+    outline: none;
+  }
+  &:global.focus-visible {
+    z-index: 1;
+    @include focusOutline();
+  }
+  &:active {
+    background-color: rgba(var(--dim-colors), 0.2);
+  }
 }

--- a/src/views/Budget/Header.tsx
+++ b/src/views/Budget/Header.tsx
@@ -119,6 +119,13 @@ export default function BudgetHeader({ scrollRef, onClick }: Props) {
           ))}
         </div>
       </div>
+      <button
+        name={formatDateKey(new Date())}
+        className={styles.todayButton}
+        onClick={handleClick as any}
+      >
+        Today
+      </button>
     </Header>
   );
 }


### PR DESCRIPTION
This PR adds a today button to the titlebar which always jumps back to the current month.
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/3419838/106812756-62822a00-6670-11eb-9ef1-7f4aa1764320.png">

closes #72